### PR TITLE
Improve offline setup handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@
 | `__pycache__/` | `src/__pycache__/README.md` | Interpreter byte-code cache. |
 
 Agents **must not** add real secrets or artefacts; update the examples instead.
+
+## Offline setup
+
+Run `scripts/setup.sh` to create a virtual environment. If `vendor/wheels` contains wheel files, they will be installed without network access. When the directory is empty the script simply creates the environment and relies on the packages preloaded in this workspace.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# No external dependencies needed; environment already provides requirements
-echo "Setup complete."
+python3 -m venv .venv
+. .venv/bin/activate
+
+WHEELHOUSE="$PWD/vendor/wheels"
+
+if [ -d "$WHEELHOUSE" ] && compgen -G "$WHEELHOUSE/*.whl" > /dev/null; then
+    export PIP_FIND_LINKS="$WHEELHOUSE"
+    export PIP_NO_INDEX=1
+    pip install -r requirements-test.txt
+    pip install -e .
+    pip install ruff black mypy bandit
+else
+    echo "No local wheel files found; skipping dependency installation."
+fi
+
+echo "Environment ready."

--- a/vendor/wheels/README.md
+++ b/vendor/wheels/README.md
@@ -1,0 +1,1 @@
+Place offline wheel files here if needed.


### PR DESCRIPTION
## Summary
- document offline startup in README
- expand `scripts/setup.sh` so it only installs dependencies when wheel files exist
- add a `vendor/wheels` placeholder for custom wheels

## Testing
- `bash scripts/setup.sh >/tmp/setup.log && cat /tmp/setup.log`