### PR TITLE
Add orders API with basic tests

### DIFF
--- a/src/features/orders/api/__init__.py
+++ b/src/features/orders/api/__init__.py
@@ -1,3 +1,44 @@
+"""Order API endpoints."""
+
 from fastapi import APIRouter
+from pydantic import BaseModel
+
+from typing import List
+
 
 router = APIRouter()
+
+
+class OrderCreate(BaseModel):
+    """Payload required to create an order."""
+
+    item: str
+    quantity: int
+
+
+class Order(OrderCreate):
+    """Order representation returned to clients."""
+
+    id: int
+
+
+_orders: List[Order] = []
+_next_id = 1
+
+
+@router.get("/", response_model=List[Order])
+def list_orders() -> List[Order]:
+    """Return all created orders."""
+
+    return _orders
+
+
+@router.post("/", response_model=Order, status_code=201)
+def create_order(payload: OrderCreate) -> Order:
+    """Create a new order and return it."""
+
+    global _next_id
+    order = Order(id=_next_id, **payload.dict())
+    _next_id += 1
+    _orders.append(order)
+    return order

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+client = TestClient(app)
+
+
+def test_create_and_list_orders():
+    # Ensure starting state is empty
+    resp = client.get("/orders")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    new_order = {"item": "Widget", "quantity": 3}
+    create_resp = client.post("/orders", json=new_order)
+    assert create_resp.status_code == 201
+    created = create_resp.json()
+    assert created["item"] == new_order["item"]
+    assert created["quantity"] == new_order["quantity"]
+    assert "id" in created
+
+    list_resp = client.get("/orders")
+    assert list_resp.status_code == 200
+    data = list_resp.json()
+    assert len(data) == 1
+    assert data[0] == created


### PR DESCRIPTION
## Summary
- implement in-memory order storage with create/list endpoints
- add tests for creating and retrieving orders

## Testing
- `ruff check .`
- `black --check src/features/orders/api/__init__.py tests/test_orders.py`
- `mypy src`
- `bandit -r src -q` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*