### PR TITLE
Add basic auth and order API tests

### DIFF
--- a/src/features/auth/api/__init__.py
+++ b/src/features/auth/api/__init__.py
@@ -1,3 +1,26 @@
-from fastapi import APIRouter
+"""Authentication API endpoints."""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
 
 router = APIRouter()
+
+
+class LoginRequest(BaseModel):
+    """Simple login payload."""
+
+    username: str
+    password: str
+
+
+@router.post("/login")
+def login(payload: LoginRequest) -> dict:
+    """Authenticate a user and return a fake token."""
+
+    if payload.username == "admin" and payload.password == "secret":
+        return {"token": "fake-token"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")
+
+
+__all__ = ["router", "login", "LoginRequest"]

--- a/src/features/orders/api/__init__.py
+++ b/src/features/orders/api/__init__.py
@@ -1,3 +1,38 @@
-from fastapi import APIRouter
+"""Orders API endpoints."""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
 
 router = APIRouter()
+
+
+class Order(BaseModel):
+    id: int
+    item: str
+
+
+orders_db = [
+    Order(id=1, item="apple"),
+    Order(id=2, item="orange"),
+]
+
+
+@router.get("/")
+def list_orders() -> list[Order]:
+    """Return all orders."""
+
+    return orders_db
+
+
+@router.get("/{order_id}")
+def get_order(order_id: int) -> Order:
+    """Return a single order by ID."""
+
+    for order in orders_db:
+        if order.id == order_id:
+            return order
+    raise HTTPException(status_code=404, detail="Order not found")
+
+
+__all__ = ["router", "list_orders", "get_order", "orders_db", "Order"]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,15 @@
+import pytest
+from fastapi import HTTPException
+
+from src.features.auth.api import login, LoginRequest
+
+
+def test_login_success():
+    payload = LoginRequest(username="admin", password="secret")
+    assert login(payload) == {"token": "fake-token"}
+
+
+def test_login_failure():
+    payload = LoginRequest(username="user", password="bad")
+    with pytest.raises(HTTPException):
+        login(payload)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,19 @@
+import pytest
+from fastapi import HTTPException
+
+from src.features.orders.api import list_orders, get_order, orders_db
+
+
+def test_list_orders():
+    result = list_orders()
+    assert len(result) == len(orders_db)
+
+
+def test_get_order_success():
+    result = get_order(1)
+    assert result.id == 1
+
+
+def test_get_order_not_found():
+    with pytest.raises(HTTPException):
+        get_order(999)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,0 @@
-def test_placeholder():
-    """Delete me when real tests exist."""
-    assert True


### PR DESCRIPTION
## Summary
- add simple auth login endpoint
- add simple orders listing and retrieval endpoints
- remove placeholder smoke test
- add tests covering the auth and orders APIs

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `make test` *(fails: .venv/bin/pytest: No such file or directory)*